### PR TITLE
Feature/last accessed date

### DIFF
--- a/src/Model/Entity.php
+++ b/src/Model/Entity.php
@@ -613,6 +613,18 @@ class Entity implements IdJsonInterface, IdElasticInterface
             }
         );
 
+        $today = new \DateTime();
+        foreach ($result as $item) {
+            if (
+                isset($item['type'], $item['onlineSource']) &&
+                $item['type'] === 'onlineSource' &&
+                $item['onlineSource']->name === 'DBBE'
+            ) {
+                $item['onlineSource']->lastAccessed = $today;
+            }
+        }
+
+
         return $result;
     }
 }

--- a/src/Model/OnlineSource.php
+++ b/src/Model/OnlineSource.php
@@ -87,16 +87,10 @@ class OnlineSource extends Entity
      */
     public function getDescription(): string
     {
-        $lastAccessedDate = null;
-
-        if ($this->name === 'DBBE') {
-            $lastAccessedDate = (new \DateTime())->format('Y-m-d');
-        } elseif (!empty($this->lastAccessed)) {
-            $lastAccessedDate = $this->lastAccessed->format('Y-m-d');
-        }
-
         return $this->name
-            . ($lastAccessedDate ? ' (last accessed: ' . $lastAccessedDate . ')' : '')
+            . (!empty($this->lastAccessed)
+                ? ' (last accessed: ' . $this->lastAccessed->format('Y-m-d') . ')'
+                : '')
             . '.';
     }
 

--- a/src/Model/OnlineSource.php
+++ b/src/Model/OnlineSource.php
@@ -87,8 +87,16 @@ class OnlineSource extends Entity
      */
     public function getDescription(): string
     {
+        $lastAccessedDate = null;
+
+        if ($this->name === 'DBBE') {
+            $lastAccessedDate = (new \DateTime())->format('Y-m-d');
+        } elseif (!empty($this->lastAccessed)) {
+            $lastAccessedDate = $this->lastAccessed->format('Y-m-d');
+        }
+
         return $this->name
-            . (!empty($this->lastAccessed) ? ' (last accessed: ' . $this->lastAccessed->format('Y-m-d') . ')' : '')
+            . ($lastAccessedDate ? ' (last accessed: ' . $lastAccessedDate . ')' : '')
             . '.';
     }
 

--- a/src/Model/OnlineSource.php
+++ b/src/Model/OnlineSource.php
@@ -73,6 +73,15 @@ class OnlineSource extends Entity
         return $this->lastAccessed;
     }
 
+    public function getFormattedLastAccessed(): ?string
+    {
+        if ($this->getName() === 'DBBE') {
+            return (new \DateTime())->format('Y-m-d');
+        }
+
+        return $this->lastAccessed->format('Y-m-d');
+    }
+
     /**
      * @return string
      */

--- a/src/ObjectStorage/EntityManager.php
+++ b/src/ObjectStorage/EntityManager.php
@@ -632,6 +632,18 @@ abstract class EntityManager extends ObjectManager
         }
     }
 
+    private function updateOnlineSourceAccess($id): void {
+        $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+            $id,
+            (new \DateTime())->format('Y-m-d')
+        );
+        $dbbeOnlineSourceId = 11523;
+        $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+            $dbbeOnlineSourceId,
+            (new \DateTime())->format('Y-m-d')
+        );
+    }
+
     protected function updateBibliography(
         Entity $entity,
         stdClass $bibliography,
@@ -698,7 +710,7 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'referenceType') ? $bib->referenceType->id : null,
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
-                            $newBibIds[] = $newBib->getId();
+                            $newBibIds[] = $newgBib->getId();
                         } elseif (in_array($bibType, ['onlineSource'])) {
                             $newBib = $this->container->get(BibliographyManager::class)->add(
                                 $entity->getId(),
@@ -710,10 +722,7 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
                             $newBibIds[] = $newBib->getId();
-                            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
-                                $bib->{$bibType}->id,
-                                (new \DateTime())->format('Y-m-d')
-                            );
+                            $this->updateOnlineSourceAccess($bib->{$bibType}->id);
                         } elseif (in_array($bibType, ['blogPost'])) {
                             $newBib = $this->container->get(BibliographyManager::class)->add(
                                 $entity->getId(),
@@ -751,10 +760,7 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'referenceType') ? $bib->referenceType->id : null,
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
-                            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
-                                $bib->{$bibType}->id,
-                                (new \DateTime())->format('Y-m-d')
-                            );                        }
+                            $this->updateOnlineSourceAccess($bib->{$bibType}->id);                       }
                         elseif (in_array($bibType, ['blogPost'])) {
                             $this->container->get(BibliographyManager::class)->update(
                                 $bib->id,

--- a/src/ObjectStorage/EntityManager.php
+++ b/src/ObjectStorage/EntityManager.php
@@ -633,15 +633,21 @@ abstract class EntityManager extends ObjectManager
     }
 
     private function updateOnlineSourceAccess($id): void {
-        $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
-            $id,
-            (new \DateTime())->format('Y-m-d')
-        );
+        //TODO: Cleaner fix.
         $dbbeOnlineSourceId = 11523;
-        $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
-            $dbbeOnlineSourceId,
-            (new \DateTime())->format('Y-m-d')
-        );
+        //Only update DBBE if the altered source is NOT DBBE so that manual lastModified changes are possible
+        if ($id !== $dbbeOnlineSourceId) {
+            //Update last accessed date of the source that has been changed
+            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+                $id,
+                (new \DateTime())->format('Y-m-d')
+            );
+            //Use this occasion to update DBBE to a recent last accessed
+            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+                $dbbeOnlineSourceId,
+                (new \DateTime())->format('Y-m-d')
+            );
+        }
     }
 
     protected function updateBibliography(

--- a/src/ObjectStorage/EntityManager.php
+++ b/src/ObjectStorage/EntityManager.php
@@ -710,6 +710,10 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
                             $newBibIds[] = $newBib->getId();
+                            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+                                $bib->{$bibType}->id,
+                                (new \DateTime())->format('Y-m-d')
+                            );
                         } elseif (in_array($bibType, ['blogPost'])) {
                             $newBib = $this->container->get(BibliographyManager::class)->add(
                                 $entity->getId(),
@@ -747,7 +751,11 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'referenceType') ? $bib->referenceType->id : null,
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
-                        } elseif (in_array($bibType, ['blogPost'])) {
+                            $this->container->get(OnlineSourceManager::class)->updateLastAccessed(
+                                $bib->{$bibType}->id,
+                                (new \DateTime())->format('Y-m-d')
+                            );                        }
+                        elseif (in_array($bibType, ['blogPost'])) {
                             $this->container->get(BibliographyManager::class)->update(
                                 $bib->id,
                                 $bib->{$bibType}->id,

--- a/src/ObjectStorage/EntityManager.php
+++ b/src/ObjectStorage/EntityManager.php
@@ -710,7 +710,7 @@ abstract class EntityManager extends ObjectManager
                                 property_exists($bib, 'referenceType') ? $bib->referenceType->id : null,
                                 property_exists($bib, 'image') ? $bib->image : null
                             );
-                            $newBibIds[] = $newgBib->getId();
+                            $newBibIds[] = $newBib->getId();
                         } elseif (in_array($bibType, ['onlineSource'])) {
                             $newBib = $this->container->get(BibliographyManager::class)->add(
                                 $entity->getId(),

--- a/src/ObjectStorage/OnlineSourceManager.php
+++ b/src/ObjectStorage/OnlineSourceManager.php
@@ -228,4 +228,8 @@ class OnlineSourceManager extends ObjectEntityManager
 
         return $new;
     }
+
+    public function updateLastAccessed($id, $lastAccessed) : void {
+        $this->dbs->updateLastAccessed($id, $lastAccessed);
+    }
 }

--- a/templates/OnlineSource/detail.html.twig
+++ b/templates/OnlineSource/detail.html.twig
@@ -19,11 +19,7 @@
 
                         <td>Last accessed</td>
                         <td>
-                            {% if online_source.getName() == 'DBBE' %}
-                                {{ "now"|date('d/m/Y') }}
-                            {% else %}
-                                {{ online_source.getLastAccessed()|date('d/m/Y') }}
-                            {% endif %}
+                            {{ online_source.getFormattedLastAccessed() }}
                         </td>
                     </tr>
                 {% endif %}

--- a/templates/OnlineSource/detail.html.twig
+++ b/templates/OnlineSource/detail.html.twig
@@ -16,8 +16,15 @@
                 </tr>
                 {% if online_source.getLastAccessed() is not empty %}
                     <tr>
+
                         <td>Last accessed</td>
-                        <td>{{ online_source.getLastAccessed().format('d/m/Y') }}</td>
+                        <td>
+                            {% if online_source.getName() == 'DBBE' %}
+                                {{ "now"|date('d/m/Y') }}
+                            {% else %}
+                                {{ online_source.getLastAccessed()|date('d/m/Y') }}
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endif %}
                 {% if online_source.getUrls() is not empty %}


### PR DESCRIPTION
- for DBBE, hardcode view so that last accessed is always today
- in the 'edit' screen we cannot hardcode so we actually update DBBE every time an online source is changed (bit hacky quickfix) so that the 'edit' screen doesn't end up showing dbbe as being last accessed long ago
- For other online sources, update last accessed whenever the source is added to an entity